### PR TITLE
Correção de referências a arquivos CSS e JS

### DIFF
--- a/src/_template.html
+++ b/src/_template.html
@@ -4,10 +4,10 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
-		<link rel="stylesheet" href="/css/materialize.css" />
+		<link rel="stylesheet" href="css/materialize.css" />
 		<title></title>
 	</head>
 	<body>
-		<script src="/js/materialize.js"></script>
+		<script src="js/materialize.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
A barra no começo do link pode trazer problemas, por isso foi retirada.