### PR TITLE
Correção de credentials nos fetch's algumas mudanças nas telas do Grupo 7

### DIFF
--- a/src/diario/cursos/index.html
+++ b/src/diario/cursos/index.html
@@ -60,21 +60,21 @@
 		<div id="modal-add" class="modal">
 			<div class="row modal-content">
 				<h4>Inserir curso</h4>
-				<div class="input-field col s3">
+				<div class="input-field col s12 m3">
 					<select id="departamento-inserir">
 						<option value="" disabled selected>Selecione</option>
 					</select>
 					<label for="departamento-inserir">Departamento</label>
 				</div>
-				<div class="input-field col s9">
+				<div class="input-field col s12 m9">
 					<input id="nome-inserir" type="text" />
 					<label for="nome-inserir">Nome do curso</label>
 				</div>
-				<div class="input-field col s5">
+				<div class="input-field col s12 m5">
 					<input id="horas-inserir" type="number" />
 					<label for="horas-inserir">Horas Totais</label>
 				</div>
-				<div class="input-field col s7">
+				<div class="input-field col s12 m7">
 					<input id="modalidade-inserir" type="text" />
 					<label for="modalidade-inserir">Modalidade</label>
 				</div>
@@ -86,23 +86,23 @@
 		</div>
 
 		<div id="modal-atualizar" class="modal">
-			<h4 style="padding: 15pt;">Atualizar curso</h4>
 			<div class="row modal-content">
-				<div class="input-field col s4">
+				<h4>Atualizar curso</h4>
+				<div class="input-field col s12 m4">
 					<select id="departamento-atualizar">
 						<option value="" disabled selected>Selecione</option>
 					</select>
 					<label for="departamento-atualizar">Departamento</label>
 				</div>
-				<div class="input-field col s8">
+				<div class="input-field col s12 m8">
 					<input id="nome-atualizar" type="text" />
 					<label for="nome-atualizar">Novo nome do curso</label>
 				</div>
-				<div class="input-field col s5">
+				<div class="input-field col s12 m5">
 					<input id="horas-atualizar" type="number" />
 					<label for="horas-atualizar">Nova horas totais</label>
 				</div>
-				<div class="input-field col s7">
+				<div class="input-field col s12 m7">
 					<input id="modalidade-atualizar" type="text" />
 					<label for="modalidade-atualizar">Nova modalidade</label>
 				</div>

--- a/src/js/biblioteca/relatorios/pesquisaDescartes.js
+++ b/src/js/biblioteca/relatorios/pesquisaDescartes.js
@@ -1,6 +1,8 @@
 const consultar = async () => {
 	const DOM = new DOMParser()
-	const res = await fetch(baseURL + '/descartes/consulta')
+	const res = await fetch(baseURL + '/descartes/consulta', {
+		credentials: 'include'
+	})
 	const text = await res.text()
 
 	return DOM.parseFromString(text, 'text/xml')

--- a/src/js/biblioteca/relatorios/pesquisaEmprestimo.js
+++ b/src/js/biblioteca/relatorios/pesquisaEmprestimo.js
@@ -1,6 +1,8 @@
 const consultar = async () => {
 	const DOM = new DOMParser()
-	const res = await fetch(baseURL + '/emprestimos/consultar')
+	const res = await fetch(baseURL + '/emprestimos/consultar', {
+		credentials: 'include'
+	})
 	const text = await res.text()
 
 	return DOM.parseFromString(text, 'text/xml')

--- a/src/js/diario/cursos/display.js
+++ b/src/js/diario/cursos/display.js
@@ -92,7 +92,7 @@ function limpaInputs(inputType) {
 }
 
 function preencherInput() {
-	fetch('http://localhost:8080/app/diario/departamentos/consulta')
+	fetch('http://localhost:8080/app/diario/departamentos/consulta', { credentials: 'include' })
 		.then(response => response.text())
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(xml => {

--- a/src/js/diario/cursos/services/atualizar.js
+++ b/src/js/diario/cursos/services/atualizar.js
@@ -1,17 +1,26 @@
 function atualizar(departamento, nome, horas, modalidade) {
-	let req = {};
+	let body = {};
 
-	req.id = currentId;
+	body.id = currentId;
 	if (departamento)
-		req.departamento = departamento;
+		body.departamento = departamento;
 	if (nome)
-		req.nome = nome;
+		body.nome = nome;
 	if (horas)
-		req.horas = horas;
+		body.horas = horas;
 	if (modalidade)
-		req.modalidade = modalidade;
+		body.modalidade = modalidade;
 
-	postFetch(baseURL + 'atualizar', req)
+	fetch(baseURL + 'atualizar', {
+		credentials: 'include',
+		method: 'POST',
+		body: new URLSearchParams(body),
+		headers: new Headers({
+			'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
+		})
+	})
+		.then(response => response.text())
+		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(data => (retornaResposta(data)))
 		.then(resposta => {
 			if (resposta == "Atualizado com sucesso.") {

--- a/src/js/diario/cursos/services/atualizar.js
+++ b/src/js/diario/cursos/services/atualizar.js
@@ -1,4 +1,5 @@
 function atualizar(departamento, nome, horas, modalidade) {
+	let statusCode
 	let body = {};
 
 	body.id = currentId;
@@ -19,14 +20,21 @@ function atualizar(departamento, nome, horas, modalidade) {
 			'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
 		})
 	})
-		.then(response => response.text())
+		.then(response => {
+			statusCode = response.status
+			return response.text()
+		})
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(data => (retornaResposta(data)))
 		.then(resposta => {
-			if (resposta == "Atualizado com sucesso.") {
+			if (statusCode == 200) {
 				M.toast({ html: resposta, classes: 'utils sucesso-2 text-light-text' })
 			} else {
-				M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				if (statusCode == 403) {
+					M.toast({ html: "Você não tem permissão para fazer esta ação", classes: 'utils erro-2 text-light-text' })
+				} else {
+					M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				}
 			}
 		})
 		.then(() => consultar())

--- a/src/js/diario/cursos/services/consultar.js
+++ b/src/js/diario/cursos/services/consultar.js
@@ -1,6 +1,15 @@
 function consultar() {
+	let statusCode
 	fetch(baseURL + 'consultar', { credentials: 'include' })
-		.then(response => response.text())
+		.then(response => {
+			statusCode = response.status
+			return response.text()
+		})
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
-		.then(xml => criaTabela(xml))
+		.then(xml => {
+			if (statusCode != 403)
+				criaTabela(xml)
+			else
+				M.toast({ html: "Você não tem permissão para visualizar este conteúdo", classes: 'utils erro-2 text-light-text' })
+		})
 }

--- a/src/js/diario/cursos/services/consultar.js
+++ b/src/js/diario/cursos/services/consultar.js
@@ -1,5 +1,5 @@
 function consultar() {
-	fetch(baseURL + 'consultar')
+	fetch(baseURL + 'consultar', { credentials: 'include' })
 		.then(response => response.text())
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(xml => criaTabela(xml))

--- a/src/js/diario/cursos/services/deletar.js
+++ b/src/js/diario/cursos/services/deletar.js
@@ -1,5 +1,5 @@
 function deletar() {
-	fetch(baseURL + 'deletar?id=' + currentId)
+	fetch(baseURL + 'deletar?id=' + currentId, { credentials: 'include' })
 		.then(response => response.text())
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(xml => (retornaResposta(xml)))

--- a/src/js/diario/cursos/services/deletar.js
+++ b/src/js/diario/cursos/services/deletar.js
@@ -1,14 +1,22 @@
 function deletar() {
+	let statusCode;
 	fetch(baseURL + 'deletar?id=' + currentId, { credentials: 'include' })
-		.then(response => response.text())
+		.then(response => {
+			statusCode = response.status
+			return response.text()
+		})
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(xml => (retornaResposta(xml)))
 		.then(resposta => {
-			if (resposta == "Deletado com sucesso.") {
+			if (statusCode == 200) {
 				M.toast({ html: resposta, classes: 'utils sucesso-2 text-light-text' })
 			} else {
-				M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				if (statusCode == 403) {
+					M.toast({ html: "Você não tem permissão para fazer esta ação", classes: 'utils erro-2 text-light-text' })
+				} else {
+					M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				}
 			}
 		}).then(() => consultar())
-		.catch(err => console.log(err))
+		.catch(err => console.error(err))
 }

--- a/src/js/diario/cursos/services/inserir.js
+++ b/src/js/diario/cursos/services/inserir.js
@@ -1,5 +1,15 @@
 function inserir(departamento, nome, horas, modalidade) {
-	postFetch(baseURL + 'inserir', { departamento, nome, horas, modalidade })
+	body = { departamento, nome, horas, modalidade }
+	fetch(baseURL + 'inserir', {
+		credentials: 'include',
+		method: 'POST',
+		body: new URLSearchParams(body),
+		headers: new Headers({
+			'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
+		})
+	})
+		.then(response => response.text())
+		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(data => (retornaResposta(data)))
 		.then(resposta => {
 			if (resposta == "Inserido com sucesso.") {

--- a/src/js/diario/cursos/services/inserir.js
+++ b/src/js/diario/cursos/services/inserir.js
@@ -1,5 +1,6 @@
 function inserir(departamento, nome, horas, modalidade) {
-	body = { departamento, nome, horas, modalidade }
+	let statusCode
+	let body = { departamento, nome, horas, modalidade }
 	fetch(baseURL + 'inserir', {
 		credentials: 'include',
 		method: 'POST',
@@ -8,14 +9,21 @@ function inserir(departamento, nome, horas, modalidade) {
 			'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
 		})
 	})
-		.then(response => response.text())
+		.then(response => {
+			statusCode = response.status
+			return response.text()
+		})
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(data => (retornaResposta(data)))
 		.then(resposta => {
-			if (resposta == "Inserido com sucesso.") {
-				M.toast({ html: 'Adicionado com sucesso.', classes: 'utils sucesso-2 text-light-text' })
+			if (statusCode == 200) {
+				M.toast({ html: resposta, classes: 'utils sucesso-2 text-light-text' })
 			} else {
-				M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				if (statusCode == 403) {
+					M.toast({ html: "Você não tem permissão para fazer esta ação", classes: 'utils erro-2 text-light-text' })
+				} else {
+					M.toast({ html: resposta, classes: 'utils erro-2 text-light-text' })
+				}
 			}
 		})
 		.then(() => consultar())

--- a/src/js/diario/cursos/services/main.js
+++ b/src/js/diario/cursos/services/main.js
@@ -1,19 +1,6 @@
 const baseURL = 'http://localhost:8080/app/diario/cursos/';
 let currentId;
 
-function postFetch(url, data) {
-	return fetch(url, {
-		credentials: 'include',
-		method: 'POST',
-		body: new URLSearchParams(data),
-		headers: new Headers({
-			'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
-		}),
-	})
-		.then(response => response.text())
-		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
-}
-
 function nomeDepto(id) {
 	return fetch('http://localhost:8080/app/diario/departamentos/consulta?id=' + id, { credentials: 'include' })
 		.then(response => response.text())

--- a/src/js/diario/cursos/services/main.js
+++ b/src/js/diario/cursos/services/main.js
@@ -3,6 +3,7 @@ let currentId;
 
 function postFetch(url, data) {
 	return fetch(url, {
+		credentials: 'include',
 		method: 'POST',
 		body: new URLSearchParams(data),
 		headers: new Headers({
@@ -14,7 +15,7 @@ function postFetch(url, data) {
 }
 
 function nomeDepto(id) {
-	return fetch('http://localhost:8080/app/diario/departamentos/consulta?id=' + id)
+	return fetch('http://localhost:8080/app/diario/departamentos/consulta?id=' + id, { credentials: 'include' })
 		.then(response => response.text())
 		.then(str => (new window.DOMParser()).parseFromString(str, "text/xml"))
 		.then(xml => {


### PR DESCRIPTION
# [Grupo 7] Correções necessárias nas telas de manutenção de cursos e nos relatórios 4, 5 e 6

Além de corrigir os ```fetch's``` adicionando credentials, foram melhorados outros pontos:

* Responsividade da página de manutenção de cursos
* *Toasts* de erro relacionados à falta de permissão do usuário

## Observação

Assim como estava antes, para testar o relatório 6 de biblioteca, é necessário o servidor que tem a parte de descartes implementada (nesse momento não está na branch dev-s1 do servidor). 